### PR TITLE
Using raise instead, throw wraps the error

### DIFF
--- a/lib/ex_ray.ex
+++ b/lib/ex_ray.ex
@@ -179,7 +179,7 @@ defmodule ExRay do
             super(unquote_splicing(params))
           rescue
             err -> unquote(post)(ctx, pre, err)
-                   throw err
+                   raise err
           else
             res -> unquote(post)(ctx, pre, res)
                    res


### PR DESCRIPTION
Using `throw` does not reflect the original error being generated. For example:

With `throw` in `gen_body/3` pre you get:

```
** (throw) %Ecto.NoResultsError{message: "expected at least one result but got none in query:\n\nfrom u in MyApp.User,\n  where: u.id == ^550\n"}
```

But with `raise` I get:

```
     ** (Ecto.NoResultsError) expected at least one result but got none in query:
     
     from u in MyApp.User,
       where: u.id == ^546
```