### PR TITLE
Use raise with the original stacktrace

### DIFF
--- a/lib/ex_ray.ex
+++ b/lib/ex_ray.ex
@@ -179,7 +179,7 @@ defmodule ExRay do
             super(unquote_splicing(params))
           rescue
             err -> unquote(post)(ctx, pre, err)
-                   throw err
+                   reraise(err, System.stacktrace())
           else
             res -> unquote(post)(ctx, pre, res)
                    res


### PR DESCRIPTION
It is wiser to use `raise` where `raise` was used before.
Some logic might rely on it.

Difference with the https://github.com/derailed/ex_ray/pull/4 is that I also add proper stacktrace to it.